### PR TITLE
Typeahead module: handle failures

### DIFF
--- a/talks/events/typeahead.py
+++ b/talks/events/typeahead.py
@@ -8,6 +8,9 @@ from django.core.cache import caches as django_caches
 
 log = logging.getLogger(__name__)
 
+# timeout (in seconds) for external requests
+FETCH_EXTERNAL_API_TIMEOUT = 2
+
 
 class Typeahead(forms.TextInput):
     """
@@ -134,7 +137,7 @@ class DataSource(object):
         if missing:
             url = self.get_prefetch_url(missing)
             log.debug("prefetch_url: %s", url)
-            response = requests.get(url)
+            response = requests.get(url, timeout=FETCH_EXTERNAL_API_TIMEOUT)
             response.raise_for_status()
             fetched = get_objects_from_response(response, self.prefetch_response_expression)
             log.debug("fetched from response: %s", fetched)


### PR DESCRIPTION
WIP

See #158, also should try/except all requests exception, do appropriate logging and return empty list or more specialised exception that can be handled by the application.

The aim is to provide partial availability. If, for example, the mobile oxford API wasn't available, the event view page should not error but simply not display the details of the venue.
