### PR TITLE
Healthcheck

### DIFF
--- a/talks/core/healthchecks.py
+++ b/talks/core/healthchecks.py
@@ -1,0 +1,70 @@
+import logging
+from haystack.query import SearchQuerySet
+
+import requests
+
+from django.http.response import HttpResponse
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def healthcheck(request):
+    checks = {'DB': _test_db_connection,
+              'Topics': _test_topics_connection,
+              'Events search': _test_events_search}
+    response = HttpResponse()
+    overall_ok = True
+    for name, service in checks.iteritems():
+        try:
+            ok, message = service()
+        except Exception as e:
+            ok = False
+            message = e
+            logger.error('Error in healthcheck {name}'.format(name=name), exc_info=True)
+        if not ok:
+            overall_ok = False
+            response.write('* !! {service}: {text}\n'.format(service=name, text=message))
+        else:
+            response.write('* {service}: {text}\n'.format(service=name, text=message.replace('\n', '')))
+    response['Content-Type'] = "text/plain; charset=utf-8"
+    response['Cache-Control'] = "must-revalidate,no-cache,no-store"
+    if overall_ok:
+        response.status_code = 200
+    else:
+        response.status_code = 500
+    return response
+
+
+def _test_db_connection():
+    from talks.events.models import Event
+    try:
+        count = Event.objects.count()
+        if count == 0:
+            return False, "Event.objects.count() == 0!"
+        else:
+            return True, "OK"
+    except Exception as e:
+        return False, e.message
+
+
+def _test_topics_connection():
+    """Performs a healthcheck to the configured client
+    """
+    if not settings.TOPICS_URL:
+        return False, "TOPICS_URL is not configured"
+    try:
+        response = requests.get('{server}search?q=a'.format(server=settings.TOPICS_URL),
+                                timeout=2)
+        response.raise_for_status()
+        return response.ok, "OK"
+    except Exception as e:
+        return False, e
+
+
+def _test_events_search():
+    try:
+        SearchQuerySet().filter(content='*:*').count()
+        return True, "OK"
+    except Exception as e:
+        return False, e.message

--- a/talks/settings.py
+++ b/talks/settings.py
@@ -182,7 +182,8 @@ HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
         'URL': 'http://127.0.0.1:8983/solr/talks',
-        'INCLUDE_SPELLING': True
+        'INCLUDE_SPELLING': True,
+        'SILENTLY_FAIL': False
     },
 }
 

--- a/talks/settings_docker.py
+++ b/talks/settings_docker.py
@@ -48,7 +48,8 @@ LOGGING = {
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
-        'URL': 'http://solr:8983/solr/collection1',
-        'INCLUDE_SPELLING': True
+        'URL': 'http://soslr:8983/solr/collection1',
+        'INCLUDE_SPELLING': True,
+        'SILENTLY_FAIL': False
     },
 }

--- a/talks/settings_docker.py
+++ b/talks/settings_docker.py
@@ -48,7 +48,7 @@ LOGGING = {
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
-        'URL': 'http://soslr:8983/solr/collection1',
+        'URL': 'http://solr:8983/solr/collection1',
         'INCLUDE_SPELLING': True,
         'SILENTLY_FAIL': False
     },

--- a/talks/urls.py
+++ b/talks/urls.py
@@ -28,5 +28,5 @@ urlpatterns = patterns('',
     url(r'^audit/', include(audit_urls, namespace='audit')),
     url(r'^api/', include(api_urls)),
     url(r'^contributors/', include(contributors_urls)),
-    url(r'^_health', healthcheck, name='healthcheck')
+    url(r'^_health$', healthcheck, name='healthcheck')
 )

--- a/talks/urls.py
+++ b/talks/urls.py
@@ -13,6 +13,7 @@ from talks.contributors.urls import urlpatterns  as contributors_urls
 from talks.audit_trail.urls import urlpatterns as audit_urls
 from talks.events.urls import urlpatterns as events_urls
 from talks.users.views import webauth_logout
+from talks.core.healthchecks import healthcheck
 
 
 urlpatterns = patterns('',
@@ -27,4 +28,5 @@ urlpatterns = patterns('',
     url(r'^audit/', include(audit_urls, namespace='audit')),
     url(r'^api/', include(api_urls)),
     url(r'^contributors/', include(contributors_urls)),
+    url(r'^_health', healthcheck, name='healthcheck')
 )


### PR DESCRIPTION
Provide a new view `/_health` which can be used for monitoring purposes (see http://api.m.ox.ac.uk/_health for an example)

Check the connection to the database and to the search index, returns HTTP 500 if there is any issue.

