### PR TITLE
Collection api filtered by date range

### DIFF
--- a/talks/api/serializers.py
+++ b/talks/api/serializers.py
@@ -265,7 +265,18 @@ class CollectionLinksSerializer(serializers.ModelSerializer):
 
 
 class CollectionEmbedsSerializer(serializers.ModelSerializer):
-    talks = HALEventSerializer(many=True, read_only=True, source='get_all_events')
+    talks = serializers.SerializerMethodField()
+
+    def get_talks(self,obj):
+        events = obj.get_all_events()
+        if self.context.has_key('from-date') or self.context.has_key('to-date'):
+            if self.context['from-date']:
+                events = events.filter(start__gte=self.context['from-date'])
+            if self.context['to-date']:
+                events = events.filter(end__lte=self.context['to-date'])
+
+        serializer = HALEventSerializer(events, many=True, read_only=True)
+        return serializer.data
 
     class Meta:
         model = Collection

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -11,7 +11,6 @@ from django.http.response import Http404
 from rest_framework import status, permissions
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes, renderer_classes
-from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -314,14 +314,15 @@ def api_collection(request, collection_slug):
     :param collection_slug: collection slug
     :return: DRF response object
     """
+
+    # If from and to dates have been passed as request parameters, filter the events by those dates.
     from_date = parse_date(request.GET.get('from', ''))
     to_date = parse_date(request.GET.get('to', ''))
     try:
         collection = Collection.objects.get(slug=collection_slug)
         if collection.public:
             if from_date and to_date:
-                events = collection.get_all_events().filter(start__gte=from_date, end__lte=to_date)
-                serializer = EventSerializer(events, many=True)
+                serializer = HALCollectionSerializer(collection, context={'from-date': from_date, 'to-date': to_date})
                 return Response(serializer.data, status=status.HTTP_200_OK)
             else:
                 serializer = HALCollectionSerializer(collection)

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -322,10 +322,9 @@ def api_collection(request, collection_slug):
         if collection.public:
             if from_date and to_date:
                 serializer = HALCollectionSerializer(collection, context={'from-date': from_date, 'to-date': to_date})
-                return Response(serializer.data, status=status.HTTP_200_OK)
             else:
                 serializer = HALCollectionSerializer(collection)
-                return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response(serializer.data, status=status.HTTP_200_OK)
         else:
             return Response({'error': "Collection is not public"},
                         status=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
I've extended the collection search API to accept 'from' and/or 'to' parameters in yyyy-mm-dd format.
eg. usage:
http://localhost:8000/api/collections/id/3b53d97e-a2be-48f1-8922-ceceecf52847?from=2015-11-30&to=2016-02-05

I'm not convinced that extending the search API is the right thing to do - that's for searching and returning events, whereas here we're returning a collection.