### PR TITLE
User talksuser id mismatch

### DIFF
--- a/talks/api/serializers.py
+++ b/talks/api/serializers.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 
 from talks.events.models import Event, Person, EventGroup
-from talks.users.models import CollectionItem, TalksUserCollection, Collection, CollectedDepartment
+from talks.users.models import CollectionItem, TalksUserCollection, Collection, CollectedDepartment, TalksUser
 
 
 class PersonSerializer(serializers.ModelSerializer):
@@ -459,7 +459,11 @@ class TalksUserCollectionSerializer(serializers.ModelSerializer):
         model = TalksUserCollection
 
 class TalksUserSerializer(serializers.ModelSerializer):
-    
+    email = serializers.SerializerMethodField()
+
+    def get_email(self,obj):
+        return obj.user.email
+            
     class Meta:
-        fields = ('id', 'user')
+        fields = ('id', 'user', 'email')
         model = TalksUser

--- a/talks/api/serializers.py
+++ b/talks/api/serializers.py
@@ -457,3 +457,9 @@ class TalksUserCollectionSerializer(serializers.ModelSerializer):
     class Meta:
         fields = ('user', 'collection', 'role')
         model = TalksUserCollection
+
+class TalksUserSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        fields = ('id', 'user')
+        model = TalksUser

--- a/talks/api/urls.py
+++ b/talks/api/urls.py
@@ -3,7 +3,8 @@ from django.conf.urls import patterns, url
 from .views import (api_event_search_hal, api_event_search_ics, api_event_get, api_event_get_ics,
                     api_event_group, get_event_group, suggest_event_group, api_event_group_ics,
                     suggest_user, suggest_user_by_complete_email_address, api_person, api_person_ics, suggest_person, api_create_person,
-                    save_item, remove_item, subscribe_to_list, unsubscribe_from_list, api_collection, api_collection_ics)
+                    save_item, remove_item, subscribe_to_list, unsubscribe_from_list, api_collection, api_collection_ics,
+                    suggest_talksuser_by_complete_email_address)
 
 
 urlpatterns = patterns('',
@@ -17,6 +18,7 @@ urlpatterns = patterns('',
     url(r'^talks/(?P<slug>[^/]+)', api_event_get, name='event-detail'),
     url(r'^user/suggest$', suggest_user, name='api-user-suggest'),
     url(r'^user/suggest/exact$', suggest_user_by_complete_email_address, name='api-user-suggest-exact'),
+    url(r'^talksuser/suggest/exact$', suggest_talksuser_by_complete_email_address, name='api-talksuser-suggest-exact'),
     url(r'^persons/new$', api_create_person, name='api-person-create'),
     url(r'^persons/suggest$', suggest_person, name='api-person-suggest'),
     url(r'^person/(?P<person_slug>[^/]+).ics', api_person_ics, name='api-person-ics'),

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -82,7 +82,7 @@ def suggest_user_by_complete_email_address(request):
 def suggest_talksuser_by_complete_email_address(request):
     query = request.GET.get('q', '')
     talksusers = TalksUser.objects.filter(user__email=query)
-    serializer = TalksUserSerializer(users, many=True)
+    serializer = TalksUserSerializer(talksusers, many=True)
     return Response(serializer.data)
 
 

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -17,9 +17,9 @@ from talks.events.models import Event, EventGroup, Person
 from talks.users.authentication import GROUP_EDIT_EVENTS, user_in_group_or_super
 from talks.users.models import Collection, TalksUser, TalksUserCollection, CollectedDepartment, COLLECTION_ROLES_READER
 from talks.api.serializers import (PersonSerializer, EventGroupSerializer, UserSerializer,
-CollectionItemSerializer, TalksUserSerializer, TalksUserCollectionSerializer, get_item_serializer,
-                                   HALEventSerializer, HALEventGroupSerializer, HALSearchResultSerializer, EventSerializer,
-                                   HALCollectionSerializer, HALPersonSerializer)
+                                    CollectionItemSerializer, TalksUserSerializer, TalksUserCollectionSerializer, get_item_serializer,
+                                    HALEventSerializer, HALEventGroupSerializer, HALSearchResultSerializer, EventSerializer,
+                                    HALCollectionSerializer, HALPersonSerializer)
 from talks.api.services import events_search, get_event_by_slug, get_eventgroup_by_slug
 from talks.core.renderers import ICalRenderer
 from talks.core.utils import parse_date

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -17,7 +17,7 @@ from talks.events.models import Event, EventGroup, Person
 from talks.users.authentication import GROUP_EDIT_EVENTS, user_in_group_or_super
 from talks.users.models import Collection, TalksUser, TalksUserCollection, CollectedDepartment, COLLECTION_ROLES_READER
 from talks.api.serializers import (PersonSerializer, EventGroupSerializer, UserSerializer,
-                                   CollectionItemSerializer, TalksUserSerializer, TalksUserCollectionSerializer, get_item_serializer,
+CollectionItemSerializer, TalksUserSerializer, TalksUserCollectionSerializer, get_item_serializer,
                                    HALEventSerializer, HALEventGroupSerializer, HALSearchResultSerializer, EventSerializer,
                                    HALCollectionSerializer, HALPersonSerializer)
 from talks.api.services import events_search, get_event_by_slug, get_eventgroup_by_slug

--- a/talks/api/views.py
+++ b/talks/api/views.py
@@ -15,11 +15,11 @@ from rest_framework.response import Response
 
 from talks.events.models import Event, EventGroup, Person
 from talks.users.authentication import GROUP_EDIT_EVENTS, user_in_group_or_super
-from talks.users.models import Collection, TalksUserCollection, CollectedDepartment, COLLECTION_ROLES_READER
+from talks.users.models import Collection, TalksUser, TalksUserCollection, CollectedDepartment, COLLECTION_ROLES_READER
 from talks.api.serializers import (PersonSerializer, EventGroupSerializer, UserSerializer,
-                                   CollectionItemSerializer, TalksUserCollectionSerializer, get_item_serializer, HALEventSerializer,
-                                   HALEventGroupSerializer, HALSearchResultSerializer, EventSerializer, HALCollectionSerializer,
-                                   HALPersonSerializer)
+                                   CollectionItemSerializer, TalksUserSerializer, TalksUserCollectionSerializer, get_item_serializer,
+                                   HALEventSerializer, HALEventGroupSerializer, HALSearchResultSerializer, EventSerializer,
+                                   HALCollectionSerializer, HALPersonSerializer)
 from talks.api.services import events_search, get_event_by_slug, get_eventgroup_by_slug
 from talks.core.renderers import ICalRenderer
 from talks.core.utils import parse_date
@@ -74,6 +74,15 @@ def suggest_user_by_complete_email_address(request):
     query = request.GET.get('q', '')
     users = User.objects.filter(email=query)
     serializer = UserSerializer(users, many=True)
+    return Response(serializer.data)
+
+@api_view(["GET"])
+@authentication_classes((SessionAuthentication,))
+@permission_classes((IsAuthenticated, IsSuperuserOrContributor,))
+def suggest_talksuser_by_complete_email_address(request):
+    query = request.GET.get('q', '')
+    talksusers = TalksUser.objects.filter(user__email=query)
+    serializer = TalksUserSerializer(users, many=True)
     return Response(serializer.data)
 
 

--- a/talks/events/datasources.py
+++ b/talks/events/datasources.py
@@ -51,6 +51,12 @@ USERS_EMAIL_EXACT_DATA_SOURCE = typeahead.DjangoModelDataSource(
     display_key='email',
     serializer=serializers.UserSerializer
 )
+TALKSUSERS_EMAIL_EXACT_DATA_SOURCE = typeahead.DjangoModelDataSource(
+    'talksusers',
+    url='/api/talksuser/suggest/exact?q=%QUERY',
+    display_key='email',
+    serializer=serializers.TalksUserSerializer
+)
 SERIES_DATA_SOURCE_BY_SLUG = typeahead.DjangoModelDataSource(
     'series',
     url='/api/series/suggest?q=%QUERY',

--- a/talks/users/forms.py
+++ b/talks/users/forms.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.db.models.query_utils import Q
 
 from talks.events import typeahead, datasources
+from django.contrib.auth.models import User
 from talks.users.models import Collection, TalksUser, TalksUserCollection, DEFAULT_COLLECTION_NAME, COLLECTION_ROLES_EDITOR, COLLECTION_ROLES_READER, COLLECTION_ROLES_OWNER
 from talks.contributors.forms import XMLFriendlyTextField
 
@@ -22,7 +23,7 @@ class CollectionForm(forms.ModelForm):
         label="Other Editors",
         help_text="Share editing with another Talks Editor by typing in their full email address",
         required=False,
-        widget=typeahead.MultipleTypeahead(datasources.USERS_EMAIL_EXACT_DATA_SOURCE),
+        widget=typeahead.MultipleTypeahead(datasources.TALKSUSERS_EMAIL_EXACT_DATA_SOURCE),
     )
     class Meta:
         model = Collection


### PR DESCRIPTION
When adding users to a collection, the email address entered in the typeahead was doing a lookup for (django) User ID in the users_talksuser table, and saving the corresponding TalksUser as an editor to the collection. This branch changes the behaviour to lookup by TalksUser ID, as this will not necessarily be the same as the User ID.