### PR TITLE
Various speakers in txt template

### DIFF
--- a/talks/templates/events/event.txt.html
+++ b/talks/templates/events/event.txt.html
@@ -52,11 +52,14 @@
   Venue to be announced
 {% endif %}
 
-<br>Speaker{{ speakers|pluralize }}:
+{% if event.various_speakers %}
+  <br>Speaker: Various Speakers
+{% else %}
+  <br>Speaker{{ speakers|pluralize }}:
 {% for speaker in speakers %}
-    {{ speaker.name}}{% if speaker.bio %} ({{ speaker.bio }}){% endif %}{% if not forloop.last %}, {% endif %}
+  {{ speaker.name}}{% if speaker.bio %} ({{ speaker.bio }}){% endif %}{% if not forloop.last %}, {% endif %}
 {% empty %}
-    Speaker to be announced
+  Speaker to be announced
 {% endfor %}
 
 {% if event.api_organisation %}

--- a/talks/templates/events/event.txt.html
+++ b/talks/templates/events/event.txt.html
@@ -56,11 +56,12 @@
   <br>Speaker: Various Speakers
 {% else %}
   <br>Speaker{{ speakers|pluralize }}:
-{% for speaker in speakers %}
-  {{ speaker.name}}{% if speaker.bio %} ({{ speaker.bio }}){% endif %}{% if not forloop.last %}, {% endif %}
-{% empty %}
-  Speaker to be announced
-{% endfor %}
+  {% for speaker in speakers %}
+    {{ speaker.name}}{% if speaker.bio %} ({{ speaker.bio }}){% endif %}{% if not forloop.last %}, {% endif %}
+  {% empty %}
+    Speaker to be announced
+  {% endfor %}
+{% endif %}
 
 {% if event.api_organisation %}
     <br>Organising department:


### PR DESCRIPTION
Fixes a problem discussed in issue #485 where events viewed in plain text were not displaying 'Various Speakers' when they were configured to do so.