### PR TITLE
Check that Oxpoints returns a location for a given oxpoints ID

### DIFF
--- a/talks/api/serializers.py
+++ b/talks/api/serializers.py
@@ -59,14 +59,15 @@ class EventSerializer(serializers.ModelSerializer):
     def get_location(self, event):
 
         if event.location:
-            location = event.api_location
-            name = location['name']
-            if event.location_details:
-                name += " (" + event.location_details + ")"
-            location_string = name
-            if location.get('address'):
-                location_string += ", " + location.get('address')
-            return location_string
+            if event.api_location:
+                location = event.api_location
+                name = location['name']
+                if event.location_details:
+                    name += " (" + event.location_details + ")"
+                location_string = name
+                if location.get('address'):
+                    location_string += ", " + location.get('address')
+                return location_string
         elif event.location_details:
             name = event.location_details
             return name

--- a/talks/api/serializers.py
+++ b/talks/api/serializers.py
@@ -68,7 +68,7 @@ class EventSerializer(serializers.ModelSerializer):
                 if location.get('address'):
                     location_string += ", " + location.get('address')
                 return location_string
-        elif event.location_details:
+        if event.location_details:
             name = event.location_details
             return name
         else:


### PR DESCRIPTION
If an event has a location which references a deleted oxpoint, it can't return a location name when generating a calendar. Added a check to ensure that the location references a valid oxpoint before proceeding, otherwise returning "Venue to be announced".