### PR TITLE
docker-compose.yml: remove volume declaration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ db:
 web:
     build: .
     command: python manage.py runserver 0.0.0.0:8000 --settings=talks.settings_docker
-    volumes:
-        - .:/code
     ports:
         - "8000:8000"
     links:


### PR DESCRIPTION
When using docker-machine as recommended in the README file, the
instructions for getting started do not work since the web application
container fails to start.

That's because the default "local" driver for Docker volumes doesn't
work directly with docker-machine (see [1] for a discussion of this).

The existing Dockerfile already copies the web application files to the
container and removing the volume configuration allows the web
application to start. Database migration and initial user creation can
then be performed. If the volume configuration is kept, the
``manage.py`` script cannot be found because the ``/code`` directory
appears to be empty.

The downside of this change is that changes to the local files will not
be reflected until a ``docker-compose build web`` command is issued.
Depending on how a local developer prefers to work, this may lead to
confusion.

[1] https://alexanderzeitler.com/articles/docker-machine-and-docker-compose-developer-workflows/