### PR TITLE
Fix import issues for test data with Postgres

### DIFF
--- a/talks/events/fixtures/dev_data.yaml
+++ b/talks/events/fixtures/dev_data.yaml
@@ -86,7 +86,7 @@
     end: 2015-12-10 14:00:00
     group: null
     location: 'oxpoints:23233672'
-    slug: deformation-and-melts-litosphere-astenosphere-boundary
+    slug: deformation-and-melts
     start: 2015-12-10 12:00:00
     title: Feedbacks between deformation and melts in the lithosphere-asthenosphere
       boundary

--- a/talks/events/fixtures/dev_data.yaml
+++ b/talks/events/fixtures/dev_data.yaml
@@ -1,4 +1,18 @@
 - fields:
+    title: A conference
+    description: A conference featuring a diverse array of groups
+    group_type: CO
+    slug: a_conference
+  model: events.eventgroup
+  pk: 1
+- fields:
+    title: A seminar
+    description: A series of talks on something
+    group_type: SE
+    slug: a_seminar
+  model: events.eventgroup
+  pk: 2
+- fields:
     bio: JB
     email_address: 'email@email.com'
     name: James Bond
@@ -418,17 +432,3 @@
     permissions: [55, 56, 57, 43, 44, 45, 46, 47, 48, 52, 53, 54, 49, 50, 51]
   model: auth.group
   pk: 1
-- fields:
-    title: A conference
-    description: A conference featuring a diverse array of groups
-    group_type: CO
-    slug: a_conference
-  model: events.eventgroup
-  pk: 1
-- fields:
-    title: A seminar
-    description: A series of talks on something
-    group_type: SE
-    slug: a_seminar
-  model: events.eventgroup
-  pk: 2


### PR DESCRIPTION
This PR fixes a couple of issues which arise when importing the test event data into the database when using postgres as a backend. Although not explicitly mentioned in the README as being compatible with the docker-compose workflow, it is certainly the case that the ``loaddata`` command is intended to populate the DB with some test events.

Mostly these fixes are to do with Postgres actually enforcing constraints specified in the model rather than sqlite's more *laissez faire* approach.

An actual bug is that one event has a slug which is longer than the maximum length of the slug field. Less of a bug is an incorrect ordering where one test fixture depends on another which has not yet been inserted. This latter ordering error could have been caught in testing by issuing the appropriate PRAGMA to sqlite to enforce foreign key constraints.