### PR TITLE
Ensure dates in ICS use Europe/London timezone

### DIFF
--- a/talks/core/renderers.py
+++ b/talks/core/renderers.py
@@ -6,6 +6,7 @@ from rest_framework import renderers
 from icalendar import Calendar, Event
 from dateutil import parser
 
+import pytz
 
 class ICalRenderer(renderers.BaseRenderer):
     media_type = 'text/calendar'
@@ -70,4 +71,6 @@ def dt_string_to_object(string):
     :param string: string representing a date/time
     :return: python datetime object
     """
-    return parser.parse(string)
+    oxfordtime = pytz.timezone('Europe/London')
+    timeobj = parser.parse(string).astimezone(oxfordtime)
+    return timeobj


### PR DESCRIPTION
This just changes the timezone used by the dates of an event when it is exported as an ICS. It can be tested by verifying that an exported event has the correct start and end times and the time zone is listed as UK (rather than UTC) when imported into e.g. Google Calendar.