### PR TITLE
Hack for deleted departments

### DIFF
--- a/talks/users/views.py
+++ b/talks/users/views.py
@@ -67,7 +67,7 @@ def view_collection(request, collection_slug):
 
     series = collection.get_event_groups().order_by('title')
 
-    collectedDeps = collection.get_departments()
+    collectedDeps = collection.get_departments().exclude(department='oxpoints:23232729').exclude(department='oxpoints:23232677')
     departments = map(lambda cdep:DEPARTMENT_DATA_SOURCE.get_object_by_id(cdep.department), collectedDeps)
 
     collectionContributors = None


### PR DESCRIPTION
Architecturally it would be a nightmare to attempt to fix this as this code can't know whether departments are deleted before requesting them. The code that makes the request raises the response as an exception if it is an error response (in this case 400 bad request) - as it should. So that shouldn't be changed either. Hence this hack, and we will not delete oxpoints departments in the future.